### PR TITLE
fixed prettier config file

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "semi": true,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "printWidth": 100,
+  "trailingComma": "all"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/prettierrc",
   "semi": true,
   "tabWidth": 2,
+  "useTabs": false,
   "singleQuote": false,
   "printWidth": 100,
   "trailingComma": "all"

--- a/prettier/.prettierrc
+++ b/prettier/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "tabWidth": 2,
-  "useTabs": false
-}


### PR DESCRIPTION
The rules themselves are not set in stone, though I'm particularly fond of `trailingComma: "all"`, `semi: true`, and `useTabs: false`. 

## VS Code Settings

Important VS Code settings (go to user settings JSON in vs code)

These keys should be inserted into the main settings object (i.e. they should be inside of the first curly brace) and if duplicate keys exist, these should be merged with or override the other keys.

```json
  "[html]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  },
  "[css]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  },
  "[javascript]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  },
  "[json]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  },
  "[vue]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  },
  "[typescript]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  },
  
  
  "prettier.documentSelectors": ["*.vue", "*.css", "*.html", "*.ts", "*.js", "*.json"]
```